### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.pivotal.hq.plugin.tcserver</groupId>
@@ -8,7 +8,7 @@
   <packaging>jar</packaging>
 
   <name>pivotal-tcserver-plugin</name>
-  <url>http://pivotal.io</url>
+  <url>https://pivotal.io</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/altered-web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/altered-web.xml
@@ -16,7 +16,7 @@
   limitations under the License.
 -->
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
     <!-- ======================== Introduction ============================== -->
     <!-- This document defines default values for *all* web applications      -->
     <!-- loaded into this instance of Tomcat.  As each application is         -->

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/default-web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/default-web.xml
@@ -16,7 +16,7 @@
   limitations under the License.
 -->
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
     <!-- ======================== Introduction ============================== -->
     <!-- This document defines default values for *all* web applications      -->
     <!-- loaded into this instance of Tomcat.  As each application is         -->

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/web.xml
@@ -17,7 +17,7 @@
 -->
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     version="2.5">
 
   <!-- ======================== Introduction ============================== -->

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/webapps/ROOT/WEB-INF/web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/webapps/ROOT/WEB-INF/web.xml
@@ -18,7 +18,7 @@
 
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
    version="2.5">
 
   <display-name>Welcome to tc Server</display-name>

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/web.xml
@@ -17,7 +17,7 @@
 -->
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     version="2.5">
 
   <!-- ======================== Introduction ============================== -->

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/ROOT/WEB-INF/web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/ROOT/WEB-INF/web.xml
@@ -18,7 +18,7 @@
 
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
    version="2.5">
 
   <display-name>Welcome to tc Server</display-name>

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/host-manager/WEB-INF/web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/host-manager/WEB-INF/web.xml
@@ -18,7 +18,7 @@
 
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
    version="2.5"> 
 
   <display-name>Tomcat Manager Application</display-name>

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/WEB-INF/web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/WEB-INF/web.xml
@@ -18,7 +18,7 @@
 
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
    version="2.5"> 
 
   <display-name>Tomcat Manager Application</display-name>

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/test-web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/test-web.xml
@@ -17,7 +17,7 @@
 -->
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     version="2.5">
 
   <!-- ======================== Introduction ============================== -->


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://maven.hyperic.org/external (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.hyperic.org/external) result SSLHandshakeException).
* http://maven.hyperic.org/milestone (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.hyperic.org/milestone) result SSLHandshakeException).
* http://maven.hyperic.org/release (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.hyperic.org/release) result SSLHandshakeException).
* http://private.maven.springsource.com/external (403) with 1 occurrences could not be migrated:  
   ([https](https://private.maven.springsource.com/external) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://pivotal.io with 1 occurrences migrated to:  
  https://pivotal.io ([https](https://pivotal.io) result 200).
* http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd with 9 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd ([https](https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/xml/ns/javaee with 18 occurrences
* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 10 occurrences