### PR TITLE
URL Cleanup

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -94,7 +94,7 @@ this work for additional information regarding copyright ownership.
 The ASF licenses this file to You under the Apache License, Version 2.0
 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
  
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
  
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -117,7 +117,7 @@ The following components are included without modification:
 
 - log4j -
 Information: http://logging.apache.org/
-License: http://www.apache.org/licenses/LICENSE-2.0
+License: https://www.apache.org/licenses/LICENSE-2.0
 
 The following components are included with modification:
 
@@ -127,7 +127,7 @@ License: http://ant-contrib.sourceforge.net/LICENSE.txt
 
 - (portions of) APR -
 Information: http://apr.apache.org/
-License: http://www.apache.org/licenses/LICENSE-2.0
+License: https://www.apache.org/licenses/LICENSE-2.0
 
 - solaris get_mib2 -
 Information: ftp://vic.cc.purdue.edu/pub/tools/unix/solaris/get_mib2/
@@ -187,7 +187,7 @@ License: within bindings/java/src/org/hyperic/sigar/util/PrintfFormat.java
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -204,7 +204,7 @@ License: within bindings/java/src/org/hyperic/sigar/util/PrintfFormat.java
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -230,7 +230,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -248,7 +248,7 @@ limitations under the License.
 Apache License 
 
 Version 2.0, January 2004 
-http://www.apache.org/licenses/ 
+https://www.apache.org/licenses/ 
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
 

--- a/src/main/groovy/com/springsource/hq/plugin/tcserver/util/control/ControlActionFailedException.groovy
+++ b/src/main/groovy/com/springsource/hq/plugin/tcserver/util/control/ControlActionFailedException.groovy
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/com/springsource/hq/plugin/tcserver/util/control/ControlActionHelper.groovy
+++ b/src/main/groovy/com/springsource/hq/plugin/tcserver/util/control/ControlActionHelper.groovy
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/ControlCommand.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/ControlCommand.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/ControlCommandConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/ControlCommandConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/ControlCommandConverterFactory.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/ControlCommandConverterFactory.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/IdentityControlCommandConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/IdentityControlCommandConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/ListUtils.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/ListUtils.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/NonRootAgentControlCommandConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/NonRootAgentControlCommandConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/RootAgentControlCommandConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/RootAgentControlCommandConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/StandardControlCommandConverterFactory.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/StandardControlCommandConverterFactory.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/TomcatMeasurementPlugin.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/TomcatMeasurementPlugin.java
@@ -10,7 +10,7 @@ package com.springsource.hq.plugin.tcserver.plugin;
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/TomcatServerControlPlugin.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/TomcatServerControlPlugin.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/Utils.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/Utils.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/ApplicationManager.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/ApplicationManager.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/ChmodFilePermissionsChanger.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/ChmodFilePermissionsChanger.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/ChownFileOwnershipChanger.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/ChownFileOwnershipChanger.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/FileOwnershipChanger.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/FileOwnershipChanger.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/FileOwnershipChangerFactory.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/FileOwnershipChangerFactory.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/FilePermissionsChanger.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/FilePermissionsChanger.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/FilePermissionsChangerFactory.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/FilePermissionsChangerFactory.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/NoOpFileOwnershipChanger.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/NoOpFileOwnershipChanger.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/NoOpFilePermissionsChanger.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/NoOpFilePermissionsChanger.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/ObjectNameUtils.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/ObjectNameUtils.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/ScriptingApplicationManager.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/ScriptingApplicationManager.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/StandardFileOwnershipChangerFactory.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/StandardFileOwnershipChangerFactory.java
@@ -9,7 +9,7 @@ package com.springsource.hq.plugin.tcserver.plugin.appmgmt;
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/StandardFilePermissionsChangerFactory.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/StandardFilePermissionsChangerFactory.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/TomcatJmxApplicationManager.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/TomcatJmxApplicationManager.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/TomcatJmxScriptingApplicationManager.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/TomcatJmxScriptingApplicationManager.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/domain/Application.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/domain/Application.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/domain/ApplicationStatus.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/domain/ApplicationStatus.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/domain/Host.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/domain/Host.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/domain/Service.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/appmgmt/domain/Service.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/discovery/ControlScriptParser.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/discovery/ControlScriptParser.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/discovery/TcRuntime80Detector.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/discovery/TcRuntime80Detector.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/discovery/TcRuntime85Detector.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/discovery/TcRuntime85Detector.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/discovery/TcRuntimeDetector.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/discovery/TcRuntimeDetector.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/AbstractDocumentCreator.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/AbstractDocumentCreator.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/AbstractXmlElementConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/AbstractXmlElementConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/AbstractXmlParser.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/AbstractXmlParser.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/AttributeNotFoundException.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/AttributeNotFoundException.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/ContextXmlParser.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/ContextXmlParser.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/DefaultServerConfigManager.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/DefaultServerConfigManager.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/FileReadingSettingsFactory.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/FileReadingSettingsFactory.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/FileSettingsRepository.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/FileSettingsRepository.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/FileUtility.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/FileUtility.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/FileUtilityException.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/FileUtilityException.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/InvalidNodeException.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/InvalidNodeException.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/ServerConfigManager.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/ServerConfigManager.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/ServerXmlParser.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/ServerXmlParser.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/ServerXmlPropertiesRetriever.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/ServerXmlPropertiesRetriever.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/SettingsFactory.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/SettingsFactory.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/SettingsRepository.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/SettingsRepository.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/WebXmlParser.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/WebXmlParser.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/XmlElementConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/XmlElementConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/XmlParser.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/XmlParser.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/XmlPropertiesFileRetriever.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/XmlPropertiesFileRetriever.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/context/ContextContainerConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/context/ContextContainerConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/CliArgsParser.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/CliArgsParser.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/DefaultCliArgsParser.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/DefaultCliArgsParser.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/DefaultJvmOptionsConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/DefaultJvmOptionsConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/EnvironmentFactory.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/EnvironmentFactory.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/EnvironmentRepository.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/EnvironmentRepository.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/JvmOptionsConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/JvmOptionsConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/UnixFileEnvironmentRepository.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/UnixFileEnvironmentRepository.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/UnixFileReadingEnvironmentFactory.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/UnixFileReadingEnvironmentFactory.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/WindowsFileEnvironmentRepository.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/WindowsFileEnvironmentRepository.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/WindowsFileReadingEnvironmentFactory.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/WindowsFileReadingEnvironmentFactory.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/WindowsSpecificNonJvmOptsUtil.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/environment/WindowsSpecificNonJvmOptsUtil.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/general/GeneralConfigConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/general/GeneralConfigConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/resources/jdbc/DataSourceConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/resources/jdbc/DataSourceConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/resources/jdbc/DataSourcesConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/resources/jdbc/DataSourcesConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/resources/jdbc/DbcpConnectionPoolConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/resources/jdbc/DbcpConnectionPoolConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/resources/jdbc/TomcatConnectionPoolConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/resources/jdbc/TomcatConnectionPoolConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/serverdefaults/JspDefaultsConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/serverdefaults/JspDefaultsConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/serverdefaults/ServerDefaultsConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/serverdefaults/ServerDefaultsConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/serverdefaults/StaticDefaultsConverter.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/serverconfig/serverdefaults/StaticDefaultsConverter.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/wrapper/JmxUtils.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/wrapper/JmxUtils.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/plugin/wrapper/MxUtilJmxUtils.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/plugin/wrapper/MxUtilJmxUtils.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/BindableAttributes.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/BindableAttributes.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/Hierarchical.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/Hierarchical.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/Identity.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/Identity.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/Profile.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/Profile.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/ProfileMarshaller.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/ProfileMarshaller.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/Settings.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/Settings.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/ValidationUtils.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/ValidationUtils.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/Configuration.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/Configuration.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/context/ContextContainer.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/context/ContextContainer.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/context/StaticResourceCache.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/context/StaticResourceCache.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/context/WebApplicationLogger.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/context/WebApplicationLogger.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/general/AprLifecycleListener.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/general/AprLifecycleListener.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/general/GeneralConfig.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/general/GeneralConfig.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/general/JmxListener.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/general/JmxListener.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/general/ServerProperties.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/general/ServerProperties.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/jvm/Advanced.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/jvm/Advanced.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/jvm/Debug.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/jvm/Debug.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/jvm/Environment.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/jvm/Environment.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/jvm/GarbageCollection.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/jvm/GarbageCollection.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/jvm/General.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/jvm/General.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/jvm/JvmOptions.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/jvm/JvmOptions.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/jvm/Memory.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/jvm/Memory.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/serverdefaults/JspDefaults.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/serverdefaults/JspDefaults.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/serverdefaults/ServerDefaults.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/serverdefaults/ServerDefaults.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/serverdefaults/StaticDefaults.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/configuration/serverdefaults/StaticDefaults.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/Connection.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/Connection.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/ConnectionPool.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/ConnectionPool.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/DataSource.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/DataSource.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/DbcpConnectionPool.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/DbcpConnectionPool.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/DbcpDataSource.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/DbcpDataSource.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/General.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/General.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/TomcatConnectionPool.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/TomcatConnectionPool.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/TomcatDataSource.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/resources/jdbc/TomcatDataSource.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/Service.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/Service.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/connector/AjpConnector.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/connector/AjpConnector.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/connector/Connector.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/connector/Connector.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/connector/HttpConnector.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/connector/HttpConnector.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/engine/Engine.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/engine/Engine.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/engine/Host.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/engine/Host.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/engine/Logging.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/engine/Logging.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/engine/ThreadDiagnostics.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/serverconfig/services/engine/ThreadDiagnostics.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/util/application/ApplicationIdentifier.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/util/application/ApplicationIdentifier.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/util/application/ApplicationUtils.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/util/application/ApplicationUtils.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/springsource/hq/plugin/tcserver/util/tomcat/TomcatNameUtils.java
+++ b/src/main/java/com/springsource/hq/plugin/tcserver/util/tomcat/TomcatNameUtils.java
@@ -7,7 +7,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/etc/hq-plugin.xml
+++ b/src/main/resources/etc/hq-plugin.xml
@@ -12,7 +12,7 @@
         Version 2.0 (the "License”); you may not use this file except in compliance
         with the License. You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/altered-web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/altered-web.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/default-web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/default-web.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/licenses/tc-server-third-party-licenses.txt
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/licenses/tc-server-third-party-licenses.txt
@@ -294,7 +294,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
  
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
  
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -595,7 +595,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
   
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
   
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -657,7 +657,7 @@ Software is licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may
 obtain a copy of the License at:
   
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
   
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -682,7 +682,7 @@ facility.
  
 Apache License
 Version 2.0, January 2004
-http://www.apache.org/licenses/
+https://www.apache.org/licenses/
 
 
 >>> groovy-1.5.7
@@ -697,7 +697,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
  
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
  
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -751,7 +751,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
  
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
  
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -887,7 +887,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
  
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
  
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -1506,7 +1506,7 @@ Use of any of this software is governed by the terms of the license below:
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -1698,7 +1698,7 @@ Use of any of this software is governed by the terms of the license below:
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
@@ -1979,7 +1979,7 @@ The LGPL2.1 is applicable to the following component(s).
 
 Apache License
 Version 2.0, January 2004
-http://www.apache.org/licenses/
+https://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -2141,41 +2141,41 @@ Version 1.0
       1. Definitions.
           o
 
-            1.1. “Contributor” means each individual or entity that creates or 
+            1.1. ï¿½Contributorï¿½ means each individual or entity that creates or 
 contributes to the creation of Modifications.
           o
 
-            1.2. “Contributor Version” means the combination of the Original 
+            1.2. ï¿½Contributor Versionï¿½ means the combination of the Original 
 Software, prior Modifications used by a Contributor (if any), and the Modifications 
 made by that particular Contributor.
           o
 
-            1.3. “Covered Software” means (a) the Original Software, or (b) 
+            1.3. ï¿½Covered Softwareï¿½ means (a) the Original Software, or (b) 
 Modifications, or (c) the combination of files containing Original Software with 
 files containing Modifications, in each case including portions thereof.
           o
 
-            1.4. “Executable” means the Covered Software in any form other than 
+            1.4. ï¿½Executableï¿½ means the Covered Software in any form other than 
 Source Code.
           o
 
-            1.5. “Initial Developer” means the individual or entity that first makes 
+            1.5. ï¿½Initial Developerï¿½ means the individual or entity that first makes 
 Original Software available under this License.
           o
 
-            1.6. “Larger Work” means a work which combines Covered Software or 
+            1.6. ï¿½Larger Workï¿½ means a work which combines Covered Software or 
 portions thereof with code not governed by the terms of this License.
           o
 
-            1.7. “License” means this document.
+            1.7. ï¿½Licenseï¿½ means this document.
           o
 
-            1.8. “Licensable” means having the right to grant, to the maximum extent 
+            1.8. ï¿½Licensableï¿½ means having the right to grant, to the maximum extent 
 possible, whether at the time of the initial grant or subsequently acquired, any and 
 all of the rights conveyed herein.
           o
 
-            1.9. “Modifications” means the Source Code and Executable form of any of 
+            1.9. ï¿½Modificationsï¿½ means the Source Code and Executable form of any of 
 the following:
                 +
 
@@ -2192,24 +2192,24 @@ previous Modification; or
 under the terms of this License.
           o
 
-            1.10. “Original Software” means the Source Code and Executable form of 
+            1.10. ï¿½Original Softwareï¿½ means the Source Code and Executable form of 
 computer software code that is originally released under this License.
           o
 
-            1.11. “Patent Claims” means any patent claim(s), now owned or hereafter 
+            1.11. ï¿½Patent Claimsï¿½ means any patent claim(s), now owned or hereafter 
 acquired, including without limitation, method, process, and apparatus claims, in any 
 patent Licensable by grantor.
           o
 
-            1.12. “Source Code” means (a) the common form of computer software code 
+            1.12. ï¿½Source Codeï¿½ means (a) the common form of computer software code 
 in which modifications are made and (b) associated documentation included in or with 
 such code.
           o
 
-            1.13. “You” (or “Your”) means an individual or a legal entity exercising 
+            1.13. ï¿½Youï¿½ (or ï¿½Yourï¿½) means an individual or a legal entity exercising 
 rights under, and complying with all of the terms of, this License. For legal 
-entities, “You” includes any entity which controls, is controlled by, or is under 
-common control with You. For purposes of this definition, “control” means (a) the 
+entities, ï¿½Youï¿½ includes any entity which controls, is controlled by, or is under 
+common control with You. For purposes of this definition, ï¿½controlï¿½ means (a) the 
 power, direct or indirect, to cause the direction or management of such entity, 
 whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) 
 of the outstanding shares or beneficial ownership of such entity.
@@ -2319,7 +2319,7 @@ the Initial Developer.
 
             You may not offer or impose any terms on any Covered Software in Source 
 Code form that alters or restricts the applicable version of this License or the 
-recipients’ rights hereunder. You may choose to offer, and to charge a fee for, 
+recipientsï¿½ rights hereunder. You may choose to offer, and to charge a fee for, 
 warranty, support, indemnity or liability obligations to one or more recipients of 
 Covered Software. However, you may do so only on Your own behalf, and not on behalf 
 of the Initial Developer or any Contributor. You must make it absolutely clear that 
@@ -2335,7 +2335,7 @@ of warranty, support, indemnity or liability terms You offer.
 terms of this License or under the terms of a license of Your choice, which may 
 contain terms different from this License, provided that You are in compliance with 
 the terms of this License and that the license for the Executable form does not 
-attempt to limit or alter the recipient’s rights in the Source Code form from the 
+attempt to limit or alter the recipientï¿½s rights in the Source Code form from the 
 rights set forth in this License. If You distribute the Covered Software in 
 Executable form under a different license, You must make it absolutely clear that any 
 terms which differ from this License are offered by You alone, not by the Initial 
@@ -2388,7 +2388,7 @@ License.
 
       5. DISCLAIMER OF WARRANTY.
 
-      COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN “AS IS” BASIS, WITHOUT 
+      COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN ï¿½AS ISï¿½ BASIS, WITHOUT 
 WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, 
 WARRANTIES THAT THE COVERED SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A 
 PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND 
@@ -2410,7 +2410,7 @@ must remain in effect beyond the termination of this License shall survive.
 
             6.2. If You assert a patent infringement claim (excluding declaratory 
 judgment actions) against Initial Developer or a Contributor (the Initial Developer 
-or Contributor against whom You assert such claim is referred to as “Participant”) 
+or Contributor against whom You assert such claim is referred to as ï¿½Participantï¿½) 
 alleging that the Participant Software (meaning the Contributor Version where the 
 Participant is a Contributor or the Original Software where the Participant is the 
 Initial Developer) directly or indirectly infringes any patent, then any and all 
@@ -2439,7 +2439,7 @@ CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FO
 LOST PROFITS, LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR 
 ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN 
 INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT 
-APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTY’S 
+APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTYï¿½S 
 NEGLIGENCE TO THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS 
 DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO 
 THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
@@ -2447,10 +2447,10 @@ THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
 
       8. U.S. GOVERNMENT END USERS.
 
-      The Covered Software is a “commercial item,” as that term is defined in 48 
-C.F.R. 2.101 (Oct. 1995), consisting of “commercial computer software” (as that term 
-is defined at 48 C.F.R. § 252.227-7014(a)(1)) and “commercial computer software 
-documentation” as such terms are used in 48 C.F.R. 12.212 (Sept. 1995). Consistent 
+      The Covered Software is a ï¿½commercial item,ï¿½ as that term is defined in 48 
+C.F.R. 2.101 (Oct. 1995), consisting of ï¿½commercial computer softwareï¿½ (as that term 
+is defined at 48 C.F.R. ï¿½ 252.227-7014(a)(1)) and ï¿½commercial computer software 
+documentationï¿½ as such terms are used in 48 C.F.R. 12.212 (Sept. 1995). Consistent 
 with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through 227.7202-4 (June 1995), all 
 U.S. Government End Users acquire Covered Software with only those rights set forth 
 herein. This U.S. Government Rights clause is in lieu of, and supersedes, any other 
@@ -2465,11 +2465,11 @@ hereof. If any provision of this License is held to be unenforceable, such provi
 shall be reformed only to the extent necessary to make it enforceable. This License 
 shall be governed by the law of the jurisdiction specified in a notice contained 
 within the Original Software (except to the extent applicable law, if any, provides 
-otherwise), excluding such jurisdiction’s conflict-of-law provisions. Any litigation 
+otherwise), excluding such jurisdictionï¿½s conflict-of-law provisions. Any litigation 
 relating to this License shall be subject to the jurisdiction of the courts located 
 in the jurisdiction and venue specified in a notice contained within the Original 
 Software, with the losing party responsible for costs, including, without limitation, 
-court costs and reasonable attorneys’ fees and expenses. The application of the 
+court costs and reasonable attorneysï¿½ fees and expenses. The application of the 
 United Nations Convention on Contracts for the International Sale of Goods is 
 expressly excluded. Any law or regulation which provides that the language of a 
 contract shall be construed against the drafter shall not apply to this License. You 

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/catalina.policy
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/catalina.policy
@@ -5,7 +5,7 @@
 // (the "License"); you may not use this file except in compliance with
 // the License.  You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/catalina.properties
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/catalina.properties
@@ -5,7 +5,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/catalina.properties.orig
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/catalina.properties.orig
@@ -5,7 +5,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/context.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/context.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/logging.properties
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/logging.properties
@@ -5,7 +5,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/tomcat-users.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/tomcat-users.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/conf/web.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/webapps/ROOT/WEB-INF/web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/webapps/ROOT/WEB-INF/web.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/webapps/ROOT/index.html
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tcs-instance1/webapps/ROOT/index.html
@@ -11,7 +11,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
@@ -155,7 +155,7 @@
 
         <p id="footer"><br>
            &nbsp;
-           Copyright © 2008-2010 SpringSource<br>
+           Copyright ï¿½ 2008-2010 SpringSource<br>
            All Rights Reserved</p>
      </td>
    </tr>

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/catalina-tasks.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/bin/catalina-tasks.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/catalina.policy
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/catalina.policy
@@ -5,7 +5,7 @@
 // (the "License"); you may not use this file except in compliance with
 // the License.  You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/catalina.properties
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/catalina.properties
@@ -5,7 +5,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/context.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/context.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/logging.properties
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/logging.properties
@@ -5,7 +5,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/tomcat-users.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/tomcat-users.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/conf/web.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/ROOT/WEB-INF/web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/ROOT/WEB-INF/web.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/ROOT/index.html
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/ROOT/index.html
@@ -11,7 +11,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
@@ -155,7 +155,7 @@
 
         <p id="footer"><br>
            &nbsp;
-           Copyright © 2008-2010 SpringSource<br>
+           Copyright ï¿½ 2008-2010 SpringSource<br>
            All Rights Reserved</p>
      </td>
    </tr>

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/host-manager/META-INF/context.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/host-manager/META-INF/context.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/host-manager/WEB-INF/web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/host-manager/WEB-INF/web.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/host-manager/manager.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/host-manager/manager.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/401.jsp
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/401.jsp
@@ -6,7 +6,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/META-INF/context.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/META-INF/context.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/WEB-INF/web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/WEB-INF/web.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/sessionDetail.jsp
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/sessionDetail.jsp
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/sessionsList.jsp
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/sessionsList.jsp
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/status.xsd
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/status.xsd
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/xform.xsl
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/springsource-tc-server-standard-2.0.0/tomcat-6.0.25.A-RELEASE/webapps/manager/xform.xsl
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/test-catalina.properties
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/test-catalina.properties
@@ -5,7 +5,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/test-context.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/test-context.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/test-web.xml
+++ b/src/test/resources/com/springsource/hq/plugin/tcserver/plugin/serverconfig/test-web.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 4 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 169 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).